### PR TITLE
Adding markdown remark to node

### DIFF
--- a/build-types.js
+++ b/build-types.js
@@ -106,6 +106,13 @@ const getTypeDefs = (typeNames, typeMap, schema, entityTypeMap, inlineImages) =>
                     });
                   },
                 },
+                [`${field}_markdown`]: {
+                  type: 'MarkdownRemark',
+                  resolve: async (source, _, context) => {
+                    const id = source?.[`${field}_markdown`];
+                    return context.nodeModel.getNodeById({ id });
+                  },
+                },
               }
             }, {}),
           }),
@@ -124,7 +131,7 @@ const getTypeDefs = (typeNames, typeMap, schema, entityTypeMap, inlineImages) =>
             return `Strapi${unionType.name}`;
           }, {}),
         });
-      
+
       default:
         break;
     }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -30,7 +30,7 @@ exports.sourceNodes = async ({
   cache,
 }, pluginOptions) => {
   const lastFetched = pluginOptions.cache !== false ? await cache.get(`timestamp`) : null;
-  const { unstable_createNodeManifest, createNode, touchNode } = actions;
+  const { unstable_createNodeManifest, createNode, touchNode, createNodeField } = actions;
   const operations = await buildQueries(pluginOptions);
   const contentTypes = await getContentTypes(pluginOptions);
   const client = getClient(pluginOptions);
@@ -77,7 +77,14 @@ exports.sourceNodes = async ({
         await Promise.all(items.map(async item => {
           const { id, attributes } = item || {};
           const nodeId = createNodeId(`${NODE_TYPE}-${id}`);
-          const options = { nodeId, createNode, createNodeId, pluginOptions, getCache };
+          const entryNode = {
+            id: nodeId,
+            strapi_id: parseInt(id),
+            internal: {
+              type: NODE_TYPE,
+            }
+          };
+          const options = { nodeId, createNode, createNodeId, pluginOptions, getCache, createContentDigest, entryNode };
           const fields = await processFieldData(attributes, options);
           await createNode({
             ...fields,


### PR DESCRIPTION
Hey thanks for your lib,

I couldn't get the [strapi/gatsby-source-strapi](https://github.com/strapi/gatsby-source-strapi) to work properly because of optional nodes where as this lib just worked for me!

However I needed to extract both the images and get the markdown to process with remark.

I looked at what was done in [strapi/gatsby-source-strapi](https://github.com/strapi/gatsby-source-strapi) and hacked this together.

If you think it would help we can clean-up as currently using the `inlineImages.typesToParse`