### PR TITLE
Fix Strapi Date & Time types

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -32,7 +32,7 @@ const formatCollectionName = name => {
 }
 
 const getFieldType = (type, strapi = false) => {
-  if (type.name === 'DateTime') {
+  if (type.name === 'DateTime' || type.name === 'Date' || type.name === 'Time') {
     return 'Date';
   }
   if (type.name === 'Long') {
@@ -54,7 +54,7 @@ const getFieldType = (type, strapi = false) => {
 }
 
 const getTypeName = type => {
-  if (type.name === 'DateTime') {
+  if (type.name === 'DateTime' || type.name === 'Date' || type.name === 'Time') {
     return 'Date';
   }
   if (type.name === 'Long') {


### PR DESCRIPTION
In my strapi schema I had date & time types:

```
"attributes": {
    "date": {
      "type": "date",
      "required": true
    },
    "open": {
      "type": "time",
      "required": true
    },
    "close": {
      "type": "time",
      "required": true
    }
  }
```

Looks like we were only supporting `datetime`. This fixes the following error:
`Missing onError handler for invocation 'building-schema', error was 'Error: Type with name "Time" does not exists'. Stacktrace was 'Error: Type with name "Time" does not exists`